### PR TITLE
update `image` for non zero `start_t`

### DIFF
--- a/local_diffusers/pipelines/DDPM/pipeline_ddpm.py
+++ b/local_diffusers/pipelines/DDPM/pipeline_ddpm.py
@@ -107,6 +107,10 @@ class DDPMPipeline(DiffusionPipeline):
         else:
             model_input = inputs
             timesteps = self.scheduler.timesteps[-start_t:]
+            # since we do not want to use a random noise 
+            # for start_t being a non-zero step 
+            # (for example: the coarse-to-fine pattern)
+            image = inputs[:,-2:,:,:] # use coarse flow you predicted already
 
         for t in self.progress_bar(timesteps):
             # 1. predict noise model_output


### PR DESCRIPTION
Please help verify this update. This change will improve the evaluation accuracy when running `evaluate_diffusers_tile.py`.